### PR TITLE
Require authentication in production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  # Require authentication in production
+  before_action :require_authentication, if: -> { Rails.env.production? }
+
+  private
+
+  def require_authentication
+    realm = 'Ada Capstone Status App'
+    authenticate_or_request_with_http_basic(realm) do |_, password|
+      ENV['SITE_PASSWORD'].present? && password == ENV['SITE_PASSWORD']
+    end
+  end
 end


### PR DESCRIPTION
This is using HTTP Basic Auth since we don't actually even need user
accounts (and we can rely upon the server using TLS).

The password for the site can be set with the environment variable
SITE_PASSWORD and is only required when Rails is in the production
environment.